### PR TITLE
Fixed error handling

### DIFF
--- a/Chris_API.py
+++ b/Chris_API.py
@@ -69,7 +69,7 @@ def converter(filename):
         print("Chris incoming to %s" % outFile)
         return aimg
     except:
-        print("File not found")
+        return("File not found")
 
 app = Flask(__name__)
 @app.route('/chris/<name>')


### PR DESCRIPTION
The API will return "file not found" if the wrong file path is entered.